### PR TITLE
include npm v10 in package.json engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "engines": {
     "node": "^16 || ^18 || ^20",
-    "npm": "9.x.x"
+    "npm": "^9 || ^10"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Installing this module with npm v10 currently prints the following warning:

```
npm WARN config production Use `--omit=dev` instead.
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'rss-url-parser@3.0.0',
npm WARN EBADENGINE   required: { node: '^16 || ^18 || ^20', npm: '9.x.x' },
npm WARN EBADENGINE   current: { node: 'v18.18.0', npm: '10.2.0' }
npm WARN EBADENGINE }
```

I don't see why npm v10 would be a problem (seems to be working fine for me), so here's a PR to add v10 to the allow-list.